### PR TITLE
Python3 -- some additional updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,12 @@ sdkbase:
 
 test: submodule-init
 	@echo "Running unit tests"
-	nose2 -s test_scripts/py_module_tests -t src/java/us/kbase/templates
+	make test-python
 	@# todo: remove perl typecomp tests and add it as a separate target
 	$(ANT) test -DKBASE_COMMON_JAR=$(KBASE_COMMON_JAR)
+
+test-python:
+	pipenv run nose2 -s test_scripts/py_module_tests -t src/java/us/kbase/templates
 
 test-client:
 	@echo "No tests for client - this kbase module is not a service, and has no clients"

--- a/README.md
+++ b/README.md
@@ -150,11 +150,19 @@ Browse through the [doc](doc/) directory of this repo for the latest available d
 To install python dependencies, do:
 
 ```sh
-$ pip install pipenv
+$ pip3 install pipenv
 # In the project's root:
-$ pipenv install
-# To run the tests:
-$ pipenv run make test
+$ pipenv install --dev
+# To run the python tests:
+$ make test-python
 # To run the linter
 $ pipenv run flake8
+```
+
+You can reset and re-install your environment with:
+
+```sh
+$ pipenv --python 3.5
+$ pipenv clean
+$ pipenv install --dev
 ```

--- a/src/java/us/kbase/templates/authclient.py
+++ b/src/java/us/kbase/templates/authclient.py
@@ -44,8 +44,11 @@ class TokenCache(object):
         with self._lock:
             self._cache[token] = [user, _time.time()]
             if len(self._cache) > self._maxsize:
-                for i, (t, _) in enumerate(sorted(list(self._cache.items()),
-                                                  key=lambda __v: __v[1][1])):
+                sorted_items = sorted(
+                    list(self._cache.items()),
+                    key=(lambda v: v[1][1])
+                )
+                for i, (t, _) in enumerate(sorted_items):
                     if i <= self._halfmax:
                         del self._cache[t]
                     else:

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ exclude =
   */prepare_deploy_cfg.py,
   */NarrativeRunner_server_test.py,
   test_scripts
+  temp_test*
 putty-ignore =
     */__init__.py : F401,E126
     *Impl.py : E265,E266


### PR DESCRIPTION
* Added some more doc details
* Added a make target for running just the python tests with pipenv
* Fixed a flake8 syntax error found in the authclient.py template (scary)
* Added `temp_test*` into the tox.ini ignores